### PR TITLE
Improve boolean column validation

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -6,7 +6,7 @@ class Item < ApplicationRecord
                         :current_price,
                         :merchant_id
 
-  validates_inclusion_of :enabled, in: [true, false]
+  validates_exclusion_of :enabled, in: [nil]
 
   belongs_to :user, foreign_key: 'merchant_id'
   has_many :order_items

--- a/app/models/order_item.rb
+++ b/app/models/order_item.rb
@@ -7,5 +7,5 @@ class OrderItem < ApplicationRecord
                         :quantity,
                         :ordered_price
 
-  validates_inclusion_of :fulfilled, in: [true, false]
+  validates_exclusion_of :fulfilled, in: [nil]
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,7 +10,7 @@ class User < ApplicationRecord
 
   validates_uniqueness_of :email
 
-  validates_inclusion_of :enabled, in: [true, false]
+  validates_exclusion_of :enabled, in: [nil]
 
   has_many :orders
   has_many :items, foreign_key: "merchant_id"

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Item, type: :model do
     it {should validate_presence_of :image_url}
     it {should validate_presence_of :quantity}
     it {should validate_presence_of :current_price}
-    it {should validate_inclusion_of(:enabled).in_array([true,false])}
+    it {should validate_exclusion_of(:enabled).in_array([nil])}
     it {should validate_presence_of :merchant_id}
 
   end

--- a/spec/models/order_item_spec.rb
+++ b/spec/models/order_item_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe OrderItem, type: :model do
     it {should validate_presence_of :item_id}
     it {should validate_presence_of :quantity}
     it {should validate_presence_of :ordered_price}
-    it {should validate_inclusion_of(:fulfilled).in_array([true,false])}
+    it {should validate_exclusion_of(:fulfilled).in_array([nil])}
   end
 
   describe 'relationships' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe User, type: :model do
     it {should validate_presence_of :email}
     it {should validate_presence_of :password}
     it {should validate_presence_of :role}
-    it {should validate_inclusion_of(:enabled).in_array( [true, false])}
+    it {should validate_exclusion_of(:enabled).in_array([nil])}
     it {should validate_uniqueness_of :email}
     it {should define_enum_for :role}
   end


### PR DESCRIPTION
Adjusts the validation to test that our boolean columns are not nil, since shoulda matchers warn that testing inclusion of [true,false] can't actually prove only true or false are being accepted.