### PR TITLE
User show page #103

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,6 +2,7 @@ class UsersController < ApplicationController
   before_action :require_user, except: [:new, :create]
   # skip_before_action :require_user, only: [:new, :create]
   def show
+    @user = current_user
   end
 
   def create

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,0 +1,9 @@
+<h1>Welcome <%= @user.name %></h1>
+
+<p>Name: <%= @user.name %></p>
+<p>Street Address: <%= @user.street_address %></p>
+<p>State: <%= @user.state %></p>
+<p>City: <%= @user.city %></p>
+<p>Zip Code: <%= @user.zip_code %></p>
+<p>Email: <%= @user.email %></p>
+<%= link_to "Edit Profile" %>

--- a/spec/features/user/show_spec.rb
+++ b/spec/features/user/show_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "User Index Page", type: :feature do
       visit profile_path
 
       expect(page).to have_content("Name: #{@user.name}")
-      expect(page).to have_content("Street Address: #{@user.street_adress}")
+      expect(page).to have_content("Street Address: #{@user.street_address}")
       expect(page).to have_content("City: #{@user.city}")
       expect(page).to have_content("State: #{@user.state}")
       expect(page).to have_content("Zip Code: #{@user.zip_code}")

--- a/spec/features/user/show_spec.rb
+++ b/spec/features/user/show_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe "User Index Page", type: :feature do
+  describe 'As a registered user' do
+    before :each do
+      @user = create(:user)
+    end
+    it 'shows information about the user and an edit button' do
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
+
+      visit profile_path
+
+      expect(page).to have_content("Name: #{@user.name}")
+      expect(page).to have_content("Street Address: #{@user.street_adress}")
+      expect(page).to have_content("City: #{@user.city}")
+      expect(page).to have_content("State: #{@user.state}")
+      expect(page).to have_content("Zip Code: #{@user.zip_code}")
+      expect(page).to have_content("Email: #{@user.email}")
+      expect(page).to have_link("Edit Profile")
+      expect(page).to_not have_content(@user.password)
+    end
+  end
+end


### PR DESCRIPTION
Adds user information to the user's profile page.

Now displays all information except password and contains link for editing the user's information.

Closes #103 