### PR TITLE
User show edit functionality

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -5,6 +5,25 @@ class UsersController < ApplicationController
     @user = current_user
   end
 
+  def edit
+    @user = current_user
+  end
+
+  def update
+    @user = current_user
+    if update_params[:password] == ""
+      @user.update(update_params.except(:password, :password_confirmation))
+    elsif update_params[:password]
+      @user.update(update_params)
+    end
+    if @user.save
+      flash[:notice] = "You have updated your information."
+      redirect_to profile_path
+    else
+      render :edit
+    end
+  end
+
   def create
     if passwords_dont_match
       redisplay_new_form "Passwords do not match"
@@ -31,6 +50,10 @@ class UsersController < ApplicationController
   end
 
   private
+
+  def update_params
+    params.require(:user).permit(:name, :street_address, :city, :state, :zip_code, :email, :password, :password_confirmation)
+  end
 
   def redisplay_new_form(message, pre_fill = form_info)
     @user = User.new

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,6 +2,7 @@ class UsersController < ApplicationController
   before_action :require_user, except: [:new, :create]
   # skip_before_action :require_user, only: [:new, :create]
   def show
+    @user = current_user
   end
 
   def create

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,0 +1,45 @@
+<% if @user.errors.any? %>
+<ul>
+  <% @user.errors.full_messages.each do |msg| %>
+  <li><%= msg %></li>
+  <% end %>
+</ul>
+<% end %>
+
+<%= form_for @user do |f| %>
+<p>
+  <%= f.label :name %>
+  <%= f.text_field :name %>
+</p>
+<p>
+  <%= f.label :street_address, "Street Address" %>
+  <%= f.text_field :street_address %>
+</p>
+<p>
+  <%= f.label :city %>
+  <%= f.text_field :city %>
+</p>
+<p>
+  <%= f.label :state %>
+  <%= f.text_field :state %>
+</p>
+<p>
+  <%= f.label :zip_code, "Zip Code" %>
+  <%= f.text_field :zip_code %>
+</p>
+<p>
+  <%= f.label :email, "Email"%>
+  <%= f.text_field :email %>
+</p>
+<p>
+  <%= f.label :password%>
+  <%= f.password_field :password %>
+</p>
+<p>
+  <%= f.label :password_confirmation, "Confirm Password" %>
+  <%= f.password_field :password_confirmation %>
+</p>
+
+  <%= f.submit %>
+
+<% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,0 +1,9 @@
+<h1>Welcome <%= @user.name %></h1>
+
+<p>Name: <%= @user.name %></p>
+<p>Street Address: <%= @user.street_address %></p>
+<p>State: <%= @user.state %></p>
+<p>City: <%= @user.city %></p>
+<p>Zip Code: <%= @user.zip_code %></p>
+<p>Email: <%= @user.email %></p>
+<%= link_to "Edit Profile" %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,3 +1,6 @@
+<% flash.each do |type, message| %>
+  <%= content_tag :div, message, class: type %>
+<% end %>
 <h1>Welcome <%= @user.name %></h1>
 
 <p>Name: <%= @user.name %></p>
@@ -6,4 +9,4 @@
 <p>City: <%= @user.city %></p>
 <p>Zip Code: <%= @user.zip_code %></p>
 <p>Email: <%= @user.email %></p>
-<%= link_to "Edit Profile" %>
+<%= link_to "Edit Profile", edit_profile_path %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,10 +9,11 @@ Rails.application.routes.draw do
     get '/merchants/:id', to: "merchants#show", as: :merchant
   end
 
-  resources :users, only: [:create]
+  resources :users, only: [:create, :update]
+  get '/profile', to: "users#show"
+  get '/profile/edit', to: "users#edit", as: 'edit_profile'
   get '/dashboard/items', to: "merchants/items#index"
   get '/dashboard', to: 'merchants/orders#index'
-  get '/profile', to: "users#show"
   get '/cart', to: "cart#show"
   get '/merchants', to: "merchants#index"
 

--- a/spec/features/user/show_spec.rb
+++ b/spec/features/user/show_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "User Index Page", type: :feature do
       visit profile_path
 
       expect(page).to have_content("Name: #{@user.name}")
-      expect(page).to have_content("Street Address: #{@user.street_adress}")
+      expect(page).to have_content("Street Address: #{@user.street_address}")
       expect(page).to have_content("City: #{@user.city}")
       expect(page).to have_content("State: #{@user.state}")
       expect(page).to have_content("Zip Code: #{@user.zip_code}")

--- a/spec/features/user/show_spec.rb
+++ b/spec/features/user/show_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe "User Index Page", type: :feature do
       visit profile_path
 
       click_link "Edit Profile"
+
       expect(current_path).to eq(edit_profile_path)
 
       fill_in "Name", with: "steve"
@@ -32,11 +33,11 @@ RSpec.describe "User Index Page", type: :feature do
       fill_in "City", with: "ranch"
       fill_in "State", with: "co"
       fill_in "Zip Code", with: "01234"
-      fill_in "email", with: "mail@mail.com"
+      fill_in "Email", with: "mail@mail.com"
       fill_in "Password", with: "password"
       fill_in "Confirm Password", with: "password"
 
-      click_button "Edit Profile"
+      click_button "Update User"
 
       expect(current_path).to eq(profile_path)
 
@@ -48,6 +49,53 @@ RSpec.describe "User Index Page", type: :feature do
       expect(page).to have_content("Email: mail@mail.com")
       expect(page).to have_link("Edit Profile")
       expect(page).to_not have_content("password")
+
+      expect(page).to have_content("You have updated your information.")
+    end
+
+    it 'update user info if password is left blank' do
+
+      visit profile_path
+
+      click_link "Edit Profile"
+      expect(current_path).to eq(edit_profile_path)
+
+      fill_in "Name", with: "steve"
+      fill_in "Street Address", with: "123 st"
+      fill_in "City", with: "ranch"
+      fill_in "State", with: "co"
+      fill_in "Zip Code", with: "01234"
+      fill_in "Email", with: "mail@mail.com"
+
+      click_button "Update User"
+
+      expect(current_path).to eq(profile_path)
+
+      expect(page).to have_content("Name: steve")
+      expect(page).to have_content("Street Address: 123 st")
+      expect(page).to have_content("City: ranch")
+      expect(page).to have_content("State: co")
+      expect(page).to have_content("Zip Code: 01234")
+      expect(page).to have_content("Email: mail@mail.com")
+      expect(page).to have_link("Edit Profile")
+      expect(page).to_not have_content(@user.password)
+
+      expect(page).to have_content("You have updated your information.")
+    end
+
+    it "does not let a user change their email to another user's email" do
+      user_2 = create(:user)
+
+      visit profile_path
+
+      click_link "Edit Profile"
+      expect(current_path).to eq(edit_profile_path)
+
+      fill_in "Email", with: user_2.email
+
+      click_button "Update User"
+
+      expect(page).to have_content("Email has already been taken")
     end
   end
 end

--- a/spec/features/user/show_spec.rb
+++ b/spec/features/user/show_spec.rb
@@ -4,9 +4,9 @@ RSpec.describe "User Index Page", type: :feature do
   describe 'As a registered user' do
     before :each do
       @user = create(:user)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
     end
     it 'shows information about the user and an edit button' do
-      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
 
       visit profile_path
 
@@ -18,6 +18,36 @@ RSpec.describe "User Index Page", type: :feature do
       expect(page).to have_content("Email: #{@user.email}")
       expect(page).to have_link("Edit Profile")
       expect(page).to_not have_content(@user.password)
+    end
+
+    it 'lets a user edit their information' do
+
+      visit profile_path
+
+      click_link "Edit Profile"
+      expect(current_path).to eq(edit_profile_path)
+
+      fill_in "Name", with: "steve"
+      fill_in "Street Address", with: "123 st"
+      fill_in "City", with: "ranch"
+      fill_in "State", with: "co"
+      fill_in "Zip Code", with: "01234"
+      fill_in "email", with: "mail@mail.com"
+      fill_in "Password", with: "password"
+      fill_in "Confirm Password", with: "password"
+
+      click_button "Edit Profile"
+
+      expect(current_path).to eq(profile_path)
+
+      expect(page).to have_content("Name: steve")
+      expect(page).to have_content("Street Address: 123 st")
+      expect(page).to have_content("City: ranch")
+      expect(page).to have_content("State: co")
+      expect(page).to have_content("Zip Code: 01234")
+      expect(page).to have_content("Email: mail@mail.com")
+      expect(page).to have_link("Edit Profile")
+      expect(page).to_not have_content("password")
     end
   end
 end

--- a/spec/features/user/show_spec.rb
+++ b/spec/features/user/show_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe "User Index Page", type: :feature do
+  describe 'As a registered user' do
+    before :each do
+      @user = create(:user)
+    end
+    it 'shows information about the user and an edit button' do
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
+
+      visit profile_path
+
+      expect(page).to have_content("Name: #{@user.name}")
+      expect(page).to have_content("Street Address: #{@user.street_adress}")
+      expect(page).to have_content("City: #{@user.city}")
+      expect(page).to have_content("State: #{@user.state}")
+      expect(page).to have_content("Zip Code: #{@user.zip_code}")
+      expect(page).to have_content("Email: #{@user.email}")
+      expect(page).to have_link("Edit Profile")
+      expect(page).to_not have_content(@user.password)
+    end
+  end
+end


### PR DESCRIPTION
Adds routes and controller action for user edit and update functionality

Adds strong params for edit form and allows a user to update their information with or without a password. 

The user show page will update accordingly contains a link to edit the path.

Once updated the user is redirected to the profile page or the form is rerenders with errors describing what was wrong with the entered information.

If information is entered correctly a flash message will show that the information has been updated successfully.

Merge after The user show page.

Closes #102 
Closes #101 

