### PR TITLE
Order creation

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,6 +14,7 @@ class ApplicationController < ActionController::Base
   def current_user?
     current_user&.user?
   end
+
   def current_customer?
     current_user == nil || current_user&.user?
   end
@@ -42,7 +43,7 @@ class ApplicationController < ActionController::Base
       'visitor'
     end
   end
-  
+
   def render_404
     render status: 404, file: "#{Rails.root}/public/404.html"
   end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,6 +1,9 @@
 class OrdersController < ApplicationController
 before_action :require_user
 
+  def index
+  end
+
   def create
     Order.from_cart(current_user, @cart.contents)
     flash[:notice] = "Your order was created!"

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,0 +1,5 @@
+class OrdersController < ApplicationController
+  def create
+
+  end
+end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,5 +1,15 @@
 class OrdersController < ApplicationController
-  def create
+before_action :require_user
 
+  def create
+    Order.from_cart(current_user, @cart.contents)
+    flash[:notice] = "Your order was created!"
+    redirect_to profile_orders_path
+  end
+
+  private
+
+  def require_user
+    render_404 unless current_user?
   end
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -7,15 +7,24 @@ class Order < ApplicationRecord
 
   enum status: ['pending', 'packaged', 'shipped', 'cancelled']
 
+  def initialize(attributes = nil)
+    super(attributes.except(:cart))
+    add_items(attributes[:cart]) if attributes[:cart]
+  end
+
   def self.from_cart(user, cart)
-    fresh_order = self.create(user: user, status: 'pending')
+    self.create(user: user, status: 'pending', cart: cart)
+  end
+
+  private
+
+  def add_items(cart)
     cart.each do |item_id, quantity|
       item = Item.find(item_id)
-      fresh_order.order_items.create(item_id: item_id,
-                                    quantity: quantity,
-                               ordered_price: item.current_price,
-                                  created_at: fresh_order.created_at)
+      self.order_items.new(item_id: item_id,
+                          quantity: quantity,
+                     ordered_price: item.current_price,
+                        created_at: self.created_at)
     end
-    return fresh_order
   end
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -12,8 +12,8 @@ class Order < ApplicationRecord
     add_items(args[:cart]) if args && args[:cart]
   end
 
-  def self.from_cart(user, cart)
-    self.create(user: user, status: 'pending', cart: cart)
+  def self.from_cart(user, cart_contents)
+    self.create(user: user, status: 'pending', cart: cart_contents)
   end
 
   private

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -6,4 +6,16 @@ class Order < ApplicationRecord
   has_many :items, through: :order_items
 
   enum status: ['pending', 'packaged', 'shipped', 'cancelled']
+
+  def self.from_cart(user, cart)
+    fresh_order = self.create(user: user, status: 'pending')
+    cart.each do |item_id, quantity|
+      item = Item.find(item_id)
+      fresh_order.order_items.create(item_id: item_id,
+                                    quantity: quantity,
+                               ordered_price: item.current_price,
+                                  created_at: fresh_order.created_at)
+    end
+    return fresh_order
+  end
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -7,9 +7,9 @@ class Order < ApplicationRecord
 
   enum status: ['pending', 'packaged', 'shipped', 'cancelled']
 
-  def initialize(attributes = nil)
-    super(attributes.except(:cart))
-    add_items(attributes[:cart]) if attributes[:cart]
+  def initialize(args = nil)
+    super(args&.except(:cart))
+    add_items(args[:cart]) if args && args[:cart]
   end
 
   def self.from_cart(user, cart)

--- a/app/views/carts/show.html.erb
+++ b/app/views/carts/show.html.erb
@@ -9,7 +9,7 @@ Your cart is empty.
 
   <div id=checkout>
     <% if current_user %>
-      <%= button_to "Checkout" %>
+      <%= button_to "Checkout", orders_path %>
     <% else %>
       You must register or log in to checkout
       <%= link_to "Log In", login_path %> <%= link_to "Register", register_path %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,4 +29,5 @@ Rails.application.routes.draw do
   get '/register', to: "users#new"
 
   resources :items, only: [:index, :show]
+  resources :orders, only: [:create]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
   get '/dashboard/items', to: "merchants/items#index"
   get '/dashboard', to: 'merchants/orders#index'
   get '/profile', to: "users#show"
+  get '/profile/orders', to: "orders#index"
   get '/cart', to: 'carts#show'
   delete '/cart', to: 'carts#destroy'
   patch '/cart', to: 'carts#update'

--- a/spec/features/cart/show_cart_spec.rb
+++ b/spec/features/cart/show_cart_spec.rb
@@ -127,7 +127,7 @@ RSpec.describe 'Cart show page' do
     visit item_path(@item_1)
     click_button "Add to Cart"
     visit cart_path
-    
+
     within '#checkout' do
       expect(page).not_to have_content("You must register or log in to checkout")
       expect(page).not_to have_link("Log In", href: login_path)
@@ -135,6 +135,17 @@ RSpec.describe 'Cart show page' do
 
       expect(page).to have_button("Checkout")
     end
+  end
+
+  it 'creates an Order upon clicking "Checkout"' do
+    user = create(:user)
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+    visit item_path(@item_1)
+    click_button "Add to Cart"
+    visit cart_path
+    click_button "Checkout"
+
+    expect(page).to have_content("Your order was created!")
   end
 
 end

--- a/spec/features/cart/show_cart_spec.rb
+++ b/spec/features/cart/show_cart_spec.rb
@@ -127,7 +127,7 @@ RSpec.describe 'Cart show page' do
     visit item_path(@item_1)
     click_button "Add to Cart"
     visit cart_path
-    save_and_open_page
+    
     within '#checkout' do
       expect(page).not_to have_content("You must register or log in to checkout")
       expect(page).not_to have_link("Log In", href: login_path)

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -12,4 +12,23 @@ RSpec.describe Order, type: :model do
     it {should have_many :order_items}
     it {should have_many(:items).through :order_items}
   end
+
+  describe 'class methods' do
+    it '#from_cart' do
+      user = create(:user)
+      item_1, item_2, item_3, item_4 = create_list(:item, 4)
+      cart = {item_1.id.to_s => 1,
+              item_4.id.to_s => 4,
+              item_2.id.to_s => 2}
+      order = Order.from_cart(user, cart)
+
+      subject = order.order_items
+      expect(subject.first.item_id).to eq(item_1.id)
+      expect(subject.first.quantity).to eq(1)
+      expect(subject.last.item_id).to eq(item_2.id)
+      expect(subject.last.quantity).to eq(2)
+
+      expect(subject.first.created_at).to eq(subject.first.created_at)
+    end
+  end
 end


### PR DESCRIPTION
Builds upon the Cart work done by @wipegup in #152 so please ensure that is merged first.

Adds `self.from_cart` method to Order, which takes the current user and a hash of cart contents as arguments. This will create a new cart, and add a join table entry for each item in the cart.

To abide by SRP, the creation of the join table entries is performed by the new instance of Order.