### PR TITLE
Admin merchant show #79

### DIFF
--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -1,5 +1,6 @@
 class Admin::MerchantsController < Admin::BaseController
   def show
+    @merchant = User.find(params[:id])
   end
 
   def index

--- a/app/views/admin/merchants/show.html.erb
+++ b/app/views/admin/merchants/show.html.erb
@@ -1,0 +1,8 @@
+<h1><%= @merchant.id %></h1>
+
+<p>Name: <%= @merchant.name %></p>
+<p>Street Address: <%= @merchant.street_address %></p>
+<p>City: <%= @merchant.city %></p>
+<p>State: <%= @merchant.state %></p>
+<p>Zip Code: <%= @merchant.zip_code %></p>
+<p>E-Mail: <%= @merchant.email %></p>

--- a/spec/features/admin/merchant_show_spec.rb
+++ b/spec/features/admin/merchant_show_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe 'As an Admin User' do
+  describe 'admin/merchant showpage' do
+    before :each do
+      @admin = create(:admin)
+      @merchant_1 = create(:merchant)
+      @merchant_2 = create(:merchant)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@admin)
+    end
+    it 'shows all the same information that a merchant would see' do
+      visit admin_merchants_path
+
+      within "#merchant-#{@merchant_1.id}" do
+        click_link "#{@merchant_1.name}"
+      end
+
+      expect(current_path).to eq("/admin/merchants/#{@merchant_1.id}")
+
+      expect(page).to have_content("Name: #{@merchant_1.name}")
+      expect(page).to have_content("Street Address: #{@merchant_1.street_address}")
+      expect(page).to have_content("City: #{@merchant_1.city}")
+      expect(page).to have_content("State: #{@merchant_1.state}")
+      expect(page).to have_content("Zip Code: #{@merchant_1.zip_code}")
+      expect(page).to have_content("E-Mail: #{@merchant_1.email}")
+    end
+  end
+end


### PR DESCRIPTION
Implements access to a merchant's show page as an admin.

When they click the link on the merchants index it will redirect them to their showpage which shows all information about the merchant.

closes #79  