### PR TITLE
Admin upgrade downgrade users #56

### DIFF
--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -13,4 +13,19 @@ class Admin::MerchantsController < Admin::BaseController
     merchant.save
     redirect_to admin_merchants_path
   end
+
+  def downgrade
+    merchant = User.find(params[:id])
+    # binding.pry
+    if merchant.merchant?
+      merchant.items.each do |item|
+        item.enabled = false
+        item.save
+      end
+      merchant.role = 0
+      merchant.save
+      flash[:notice] = "#{merchant.name} is now a User"
+      redirect_to admin_user_path(merchant)
+    end
+  end
 end

--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -1,6 +1,9 @@
 class Admin::MerchantsController < Admin::BaseController
   def show
     @merchant = User.find(params[:id])
+    if @merchant.user?
+      redirect_to admin_user_path(@merchant)
+    end
   end
 
   def index

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -6,4 +6,14 @@ class Admin::UsersController < Admin::BaseController
   def show
     @user = User.find(params[:id])
   end
+
+  def upgrade
+    user = User.find(params[:id])
+    if user.user?
+      user.role = 1
+      user.save
+      flash[:notice] = "#{user.name} is now a Merchant"
+      redirect_to admin_merchant_path(user)
+    end
+  end
 end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -5,6 +5,9 @@ class Admin::UsersController < Admin::BaseController
 
   def show
     @user = User.find(params[:id])
+    if @user.merchant?
+      redirect_to admin_merchant_path(@user)
+    end
   end
 
   def upgrade

--- a/app/views/admin/merchants/show.html.erb
+++ b/app/views/admin/merchants/show.html.erb
@@ -1,3 +1,4 @@
+
 <h1><%= @merchant.id %></h1>
 
 <p>Name: <%= @merchant.name %></p>

--- a/app/views/admin/merchants/show.html.erb
+++ b/app/views/admin/merchants/show.html.erb
@@ -1,4 +1,3 @@
-
 <h1><%= @merchant.id %></h1>
 
 <p>Name: <%= @merchant.name %></p>
@@ -7,3 +6,5 @@
 <p>State: <%= @merchant.state %></p>
 <p>Zip Code: <%= @merchant.zip_code %></p>
 <p>E-Mail: <%= @merchant.email %></p>
+
+<%= link_to "Downgrade to User", admin_downgrade_merchant_path(@merchant) %>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -7,3 +7,4 @@
 <p>Zip Code: <%= @user.zip_code %></p>
 <p>E-Mail: <%= @user.email %></p>
 <%= link_to "Edit Profile", edit_profile_path %>
+<%= link_to "Upgrade to Merchant", admin_upgrade_user_path(@user) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
     get '/dashboard', to: "orders#index"
     resources :users, only: [:index, :show]
     get '/admin/users/:id/upgrade', to: "users#upgrade", as: 'upgrade_user'
+    get '/admin/merchants/:id/downgrade', to: "merchants#downgrade", as: 'downgrade_merchant'
     get '/merchants/:id', to: "merchants#show", as: :merchant
     get '/merchants', to: "merchants#index", as: :merchants
     patch '/merchant/:merchant_id/', to: "merchants#update", as: :merchant_change_status

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
   namespace :admin do
     get '/dashboard', to: "orders#index"
     resources :users, only: [:index, :show]
+    get '/admin/users/:id/upgrade', to: "users#upgrade", as: 'upgrade_user'
     get '/merchants/:id', to: "merchants#show", as: :merchant
     get '/merchants', to: "merchants#index", as: :merchants
     patch '/merchant/:merchant_id/', to: "merchants#update", as: :merchant_change_status

--- a/spec/features/admin/merchant_show_spec.rb
+++ b/spec/features/admin/merchant_show_spec.rb
@@ -56,5 +56,23 @@ RSpec.describe 'As an Admin User' do
 
       expect(page).to_not have_content("The page you were looking for doesn't exist")
     end
+    it 'only allows admins to reach the downgrade path' do
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user_1)
+
+      visit admin_downgrade_merchant_path(@user_1)
+      expect(page).to have_http_status(404)
+
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@merchant)
+
+      visit admin_downgrade_merchant_path(@user_1)
+      expect(page).to have_http_status(404)
+    end
+
+    it 'If a path is for merchant but the merchant is a user it is redirected to the users path' do
+
+      visit "/admin/merchants/#{@user_1.id}"
+
+      expect(current_path).to eq(admin_user_path(@user_1))
+    end
   end
 end

--- a/spec/features/admin/merchant_show_spec.rb
+++ b/spec/features/admin/merchant_show_spec.rb
@@ -27,8 +27,8 @@ RSpec.describe 'As an Admin User' do
     end
 
     it 'Allows an admin to downgrade a merchant to a user' do
-      item_1 = create(:item, merchant_id: @merchant_1.id)
-      item_2 = create(:item, merchant_id: @merchant_1.id)
+      create(:item, merchant_id: @merchant_1.id)
+      create(:item, merchant_id: @merchant_1.id)
 
       visit admin_merchant_path(@merchant_1)
 
@@ -39,8 +39,10 @@ RSpec.describe 'As an Admin User' do
       expect(current_path).to eq(admin_user_path(@merchant_1))
       expect(page).to have_content("#{@merchant_1.name} is now a User")
 
-      expect(item_1.enable?).to eq(false)
-      expect(item_2.enable?).to eq(false)
+      item_1 = Item.first
+      item_2 = Item.second
+      expect(item_1.enabled?).to eq(false)
+      expect(item_2.enabled?).to eq(false)
 
       visit admin_users_path
       expect(page).to have_link(@merchant_1.name)

--- a/spec/features/admin/users_show_spec.rb
+++ b/spec/features/admin/users_show_spec.rb
@@ -26,5 +26,22 @@ RSpec.describe "Admin User show page", type: :feature do
       expect(page).to have_content("Zip Code: #{@user_1.zip_code}")
       expect(page).to have_content("E-Mail: #{@user_1.email}")
     end
+
+    it 'Allows an admin to updrage a user to a merchant' do
+      visit admin_user_path(@user_1)
+
+      expect(page).to have_link("Upgrade to Merchant")
+
+      click_link "Upgrade to Merchant"
+
+      expect(current_path).to eq(admin_merchant_path(@user_1))
+      expect(page).to have_content("#{@user_1.name} is now a Merchant")
+
+      visit admin_users_path
+      expect(page).to_not have_link(@user_1.name)
+
+      visit admin_merchants_path
+      expect(page).to have_link(@user_1.name)
+    end
   end
 end

--- a/spec/features/admin/users_show_spec.rb
+++ b/spec/features/admin/users_show_spec.rb
@@ -42,6 +42,24 @@ RSpec.describe "Admin User show page", type: :feature do
 
       visit admin_merchants_path
       expect(page).to have_link(@user_1.name)
+
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(User.second)
+
+      visit dashboard_path
+
+      expect(page).to_not have_content("The page you were looking for doesn't exist")
+    end
+
+    it 'only allows admins to reach the upgrade path' do
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user_1)
+
+      visit admin_upgrade_user_path(@user_1)
+      expect(page).to have_http_status(404)
+
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@merchant)
+
+      visit admin_upgrade_user_path(@user_1)
+      expect(page).to have_http_status(404)
     end
   end
 end

--- a/spec/features/admin/users_show_spec.rb
+++ b/spec/features/admin/users_show_spec.rb
@@ -61,5 +61,12 @@ RSpec.describe "Admin User show page", type: :feature do
       visit admin_upgrade_user_path(@user_1)
       expect(page).to have_http_status(404)
     end
+
+    it 'If a path is for user but the user is a merchant it is redirected to the merchants path' do
+
+      visit "/admin/users/#{@merchant_1.id}"
+
+      expect(current_path).to eq(admin_merchant_path(@merchant_1))
+    end
   end
 end


### PR DESCRIPTION
Adds the ability for an admin to upgrade and downgrade users from merchant to user and vice versa.

Also adds the ability for the admin to be redirected if they enter in the incorrect URI.
If they enter '/admin/users/:id' but the ID is of a merchant they are redirected to the admin merchant path. This is also the case for a user in the merchants URI

All tests passing

closes #56 
closes #55 
closes #54 
closes #53 