### PR TITLE
Show cart test repair

### DIFF
--- a/spec/features/cart/show_cart_spec.rb
+++ b/spec/features/cart/show_cart_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+include ActionView::Helpers::NumberHelper
 
 RSpec.describe 'Cart show page' do
   before :each do
@@ -94,7 +95,7 @@ RSpec.describe 'Cart show page' do
     expect(page).not_to have_selector('div', id:"cart-item-#{@item_3.id}")
 
     total = @item_1.current_price + (@item_2.current_price * 2) + (@item_4.current_price * 4)
-    expect(page).to have_selector('div', id:"cart-actions", text:total.round(2))
+    expect(page).to have_selector('div', id:"cart-actions", text: number_to_currency(total.round(2)))
   end
 
   it 'can update quantities of items in the cart' do


### PR DESCRIPTION
Adds and include for the action views number helpers into the rspec test

Adds the number_to_currency_method to the failing test so they now expect the correct information

all tests passing.